### PR TITLE
Added fallback Commands to the GuardedSCM

### DIFF
--- a/src/org/robotlegs/core/IGuardedSignalCommandMap.as
+++ b/src/org/robotlegs/core/IGuardedSignalCommandMap.as
@@ -11,7 +11,7 @@ public interface IGuardedSignalCommandMap extends ISignalCommandMap {
 		 * <p>The <code>guards</code> must be a Class which implements an approve() method</p>
 		 * <p>or an <code>Array</code> of Classes which implements an approve() method</p>
 		 *
-		 * @param commandClass The signal instance to trigger this command. Values dispatched by this signal are available for injection into guards and the command.
+		 * @param signal The signal instance to trigger this command. Values dispatched by this signal are available for injection into guards and the command.
 		 * @param commandClass The Class to instantiate - must have an execute() method
 		 * @param guards The Classes of the guard or guards to instantiate - must have an approve() method
 		 * @param oneshot Unmap the Class after execution?
@@ -36,6 +36,44 @@ public interface IGuardedSignalCommandMap extends ISignalCommandMap {
 		 * @throws org.robotlegs.base::ContextError
 		 */
 		 function mapGuardedSignalClass(signalClass:Class, commandClass:Class, guards:*, oneShot:Boolean = false):ISignal;
+		
+		/**
+		 * Map a Command to an instance of a Signal, with Guards and a fallback Command
+		 * 
+		 * <p>The <code>signal</code> - an instance of ISignal</p>
+		 * <p>The <code>commandClass</code> must implement an execute() method - executed if the guards approve</p>
+		 * <p>The <code>fallbackCommandClass</code> must implement an execute() method - executed if the guards disapprove</p>
+		 * <p>The <code>guards</code> must be a Class which implements an approve() method</p>
+		 * <p>or an <code>Array</code> of Classes which implements an approve() method</p>
+		 *
+		 * @param signal The signal instance to trigger this command. Values dispatched by this signal are available for injection into guards and the command.
+		 * @param commandClass The Class to instantiate - must have an execute() method - exeecuted if the guards approve
+		 * @param fallbackCommandClass The Class to instantiate - must have an execute() method - executed if the guards disapprove
+		 * @param guards The Classes of the guard or guards to instantiate - must have an approve() method
+		 * @param oneshot Unmap the Class after execution?
+		 * 
+		 * @throws org.robotlegs.base::ContextError
+		*/
+		function mapGuardedSignalWithFallback(signal:ISignal, commandClass:Class, fallbackCommandClass:Class, guards:*, oneshot:Boolean = false):void;
+		
+		/**
+		 * Map a Command to an instance of a Signal, with Guards and a fallback Command 
+		 * 
+		 * <p>The <code>signalClass</code> - a Class implementing ISignal</p>
+		 * <p>The <code>commandClass</code> must implement an execute() method - executed if the guards approve</p>
+		 * <p>The <code>fallbackCommandClass</code> must implement an execute() method - executed if the guards disapprove</p>
+		 * <p>The <code>guards</code> must be a Class which implements an approve() method</p>
+		 * <p>or an <code>Array</code> of Classes which implements an approve() method</p>
+		 *
+		 * @param signal The signal class to be created - an instance of this Class is then available for injection as a singleton in the main Injector.
+		 * @param commandClass The Class to instantiate - must have an execute() method - executed if the guards approve
+		 * @param fallbackCommandClass The Class to instantiate - must have an execute() method - executed if the guards disapprove
+		 * @param guards The Classes of the guard or guards to instantiate - must have an approve() method
+		 * @param oneshot Unmap the Class after execution?
+		 * 
+		 * @throws org.robotlegs.base::ContextError
+		 */
+		 function mapGuardedSignalClassWithFallback(signalClass:Class, commandClass:Class, fallbackCommandClass:Class, guards:*, oneShot:Boolean = false):ISignal;
 		
 	}
 }

--- a/test/org/robotlegs/base/GuardedSignalCommandMapTests.as
+++ b/test/org/robotlegs/base/GuardedSignalCommandMapTests.as
@@ -162,6 +162,40 @@ package org.robotlegs.base
 			var signal:ISignal = guardedCommandMap.mapGuardedSignalClass(Signal, SampleCommandA, guard);
 			Signal(signal).dispatch();
 			assertThat(_reportedCommands, array(SampleCommandA));
-		}		
+		}
+		
+		[Test]
+		public function mapping_signal_class_with_fallback_executes_first_choice_if_guard_approves():void {             
+			var guard:Class = HappyGuard;
+			var signal:ISignal = guardedCommandMap.mapGuardedSignalClassWithFallback(Signal, SampleCommandA, SampleCommandB, guard);
+			Signal(signal).dispatch();
+			assertThat(_reportedCommands, array(SampleCommandA));
+		} 
+		
+		[Test]
+		public function mapping_signal_class_with_fallback_executes_fallback_if_guard_disapproves():void {             
+			var guard:Class = GrumpyGuard;
+			var signal:ISignal = guardedCommandMap.mapGuardedSignalClassWithFallback(Signal, SampleCommandA, SampleCommandB, guard);
+			Signal(signal).dispatch();
+			assertThat(_reportedCommands, array(SampleCommandB));
+		}
+		
+		[Test]
+		public function mapping_with_fallback_executes_first_choice_if_guard_approves():void {             
+			var guard:Class = HappyGuard;
+			var signal:Signal = new Signal();
+			guardedCommandMap.mapGuardedSignalWithFallback(signal, SampleCommandA, SampleCommandB, guard);
+			signal.dispatch();
+			assertThat(_reportedCommands, array(SampleCommandA));
+		} 
+		
+		[Test]
+		public function mapping_with_fallback_executes_fallback_if_guard_disapproves():void {             
+			var guard:Class = GrumpyGuard;
+			var signal:Signal = new Signal();
+			guardedCommandMap.mapGuardedSignalWithFallback(signal, SampleCommandA, SampleCommandB, guard);
+			signal.dispatch();
+			assertThat(_reportedCommands, array(SampleCommandB));
+		}   	
     }
 }


### PR DESCRIPTION
With tests. Added the fallback variations of the API - which allow you to specify a command to be executed if the guards disapprove.

Let me know whether you want to keep all this together, or think the GSCM needs to be split off.

Stray
