### PR TITLE
Minimal detain and release functionality

### DIFF
--- a/src/org/robotlegs/base/SignalCommandMap.as
+++ b/src/org/robotlegs/base/SignalCommandMap.as
@@ -13,6 +13,7 @@ package org.robotlegs.base
         protected var signalMap:Dictionary;
         protected var signalClassMap:Dictionary;
         protected var verifiedCommandClasses:Dictionary;
+        protected var detainedCommands:Dictionary;
 
         public function SignalCommandMap(injector:IInjector)
         {
@@ -20,6 +21,7 @@ package org.robotlegs.base
             signalMap = new Dictionary( false );
             signalClassMap = new Dictionary( false );
             verifiedCommandClasses = new Dictionary( false );
+            detainedCommands = new Dictionary( false );
         }
 
         public function mapSignal(signal:ISignal, commandClass:Class, oneShot:Boolean = false):void
@@ -119,5 +121,15 @@ package org.robotlegs.base
 			verifiedCommandClasses[commandClass] = true;
         }
 		
+        public function detain(command:Object):void
+        {
+            detainedCommands[command] = true;
+        }
+
+        public function release(command:Object):void
+        {
+            if (detainedCommands[command])
+                delete detainedCommands[command];
+        }
     }
 }

--- a/src/org/robotlegs/core/ISignalCommandMap.as
+++ b/src/org/robotlegs/core/ISignalCommandMap.as
@@ -13,5 +13,9 @@ package org.robotlegs.core
         function unmapSignal(signal:ISignal, commandClass:Class):void;
 		
         function unmapSignalClass(signalClass:Class, commandClass:Class):void;
+
+        function detain(command:Object):void;
+
+        function release(command:Object):void;
     }
 }

--- a/test/org/robotlegs/base/SignalCommandMapProtectedTests.as
+++ b/test/org/robotlegs/base/SignalCommandMapProtectedTests.as
@@ -1,0 +1,75 @@
+package org.robotlegs.base
+{
+	import flash.utils.Dictionary;
+	
+	import org.flexunit.asserts.*;
+	import org.robotlegs.adapters.SwiftSuspendersInjector;
+	import org.robotlegs.core.IInjector;
+	import org.robotlegs.test.support.TestNoPropertiesCommand;
+	
+	public class SignalCommandMapProtectedTests extends SignalCommandMap
+	{
+		public function SignalCommandMapProtectedTests()
+		{
+			super(null);
+		}
+		
+		[Before]
+		public function setup():void
+		{
+			this.injector = new SwiftSuspendersInjector();
+			this.signalMap = new Dictionary( false );
+			this.signalClassMap = new Dictionary( false );
+			this.verifiedCommandClasses = new Dictionary( false );
+			this.detainedCommands = new Dictionary( false );
+		}
+		
+		[After]
+		public function teardown():void
+		{
+			this.injector = null;
+			this.signalMap = null;
+			this.signalClassMap = null;
+			this.verifiedCommandClasses = null;
+			this.detainedCommands = null;
+		}
+		
+		[Test]
+		public function test_detain_and_release():void
+		{
+			var command:Object = new TestNoPropertiesCommand();
+			detain(command);
+			assertTrue('detainedCommands Dictionary should contain command following detain call', detainedCommands[command]);
+			release(command);
+			assertTrue('detainedCommands Dictionary should not contain command following release call', detainedCommands[command] == undefined);
+		}
+		
+		[Test]
+		public function test_detain_twice_and_release():void
+		{
+			var command:Object = new TestNoPropertiesCommand();
+			detain(command);
+			detain(command);
+			release(command);
+			assertTrue('A single release call should be sufficient to remove a detained command, regardless of the number of detain calls', detainedCommands[command] == undefined);
+		}
+		
+		[Test]
+		public function test_release_without_detain():void
+		{
+			var command:Object = new TestNoPropertiesCommand();
+			release(command);
+			assertTrue('releasing a command that was not detained should not cause an error', true);
+		}
+		
+		[Test]
+		public function test_detain_release_null_object():void
+		{
+			var command:Object = null;
+			detain(command);
+			assertTrue('detainedCommands Dictionary should contain null command object following detain call', detainedCommands[command]);
+			release(command);
+			assertTrue('detainedCommands Dictionary should not contain null command following release call', detainedCommands[command] == undefined);
+		}
+	}
+}


### PR DESCRIPTION
Adding detain and release functions to `ISignalCommandMap` and `SignalCommandMap` to accomplish closer parity with the reference event-based `CommandMap` and ease the creation of asynchronously-executing commands. I am aware that various other branches have implemented this functionality in addition to other neat utility enhancements, but I thought it would be valuable to the community if Joel's canonical fork contained at least these basic functions for reference. 

The most contentious decision made in this commit was to use generic `Object`s as acceptable parameters for the detain and release functions, rather than `ISignalCommand` or some new `ICommand` type. This choice was in keeping with the core Robotlegs' intentional sidestepping of strong command typing in favor of supporting any `Object` with an `execute()` method and results in equivalent signatures for these methods in the `ICommandMap` and `ISignalCommandMap` interfaces.
